### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: compile
+
+compile:
+	rebar -v compile
+
+test:
+	rebar -v eunit
+
+clean:
+	rebar clean

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: compile
 
 compile:
-	rebar -v compile
+	rebar -v compile skip_deps=true
 
 test:
-	rebar -v eunit
+	rebar -v eunit skip_deps=true
 
 clean:
-	rebar clean
+	rebar clean skip_deps=true

--- a/erlang-bifrost.spec
+++ b/erlang-bifrost.spec
@@ -2,7 +2,7 @@
 %global upstream madrat-
 %global debug_package %{nil}
 
-%global git_url http://github.com/%{upstream}/%{realname}
+%global git_url https://github.com/%{upstream}/%{realname}
 
 %if 0%{!?git_tag:1}
 %global git_tag HEAD
@@ -34,7 +34,7 @@ License:	MIT
 URL:		%{git_url}
 
 BuildRequires:	erlang-rebar
-BuildRequires:	erlang-meck >= 0.8.1
+%{!?_without_check:BuildRequires:  erlang-meck >= 0.8.1}
 
 Requires:	erlang-compiler%{?_isa}
 Requires:	erlang-crypto%{?_isa}
@@ -44,7 +44,6 @@ Requires:	erlang-kernel%{?_isa}
 Requires:	erlang-ssl%{?_isa}
 Requires:	erlang-stdlib%{?_isa} >= R16
 Requires:	erlang-syntax_tools%{?_isa}
-Requires:	erlang-meck >= 0.8.1
 Provides:	%{realname} = %{version}-%{release}
 
 
@@ -59,6 +58,7 @@ This version is fork of https://github.com/thorstadt/bifrost
 %setup -n %{upstream}-%{realname}-%{version} -T -c
 git clone -q %{git_url} `pwd`
 git reset -q --hard %{git_tag}
+%{?_without_check:sed -rne '/meck/!p' -i.meck rebar.config}
 
 %build
 make

--- a/erlang-bifrost.spec
+++ b/erlang-bifrost.spec
@@ -2,7 +2,7 @@
 %global upstream madrat-
 %global debug_package %{nil}
 
-%global commit		5afbc6241b5b9444a4c94aefb92f892ea36b660e
+%global commit		e0518257d4eada8ee25e730fb15b448e646cab92
 %global commit_time 20141113
 %global git_tag %(c=%{commit}; echo ${c:0:8})
 %global patchnumber 0
@@ -16,7 +16,7 @@ Summary:	Pluggable Erlang FTP Server
 Group:		Development/Libraries
 License:	MIT
 URL:		http://github.com/madrat-/bifrost
-Source0:	%{upstream}-%{realname}-%{version}-%{git_tag}.tar.bz2
+#Source0:	%{upstream}-%{realname}-%{version}-%{git_tag}.tar.bz2
 
 BuildRequires:	erlang-rebar
 BuildRequires:	erlang-meck >= 0.8.1
@@ -41,21 +41,12 @@ Bifrost also includes FTP/SSL support, if you supply a certificate.
 This version is fork of https://github.com/thorstadt/bifrost
 
 %prep
-%setup -q -n %{upstream}-%{realname}-%{version}
-%patch0 -p1 -b .no_deps
-#%patch1 -p2 -b .fix_eunit
-#%patch2 -p1 -b .disconnect
-#%patch3 -p1 -b .up_notifs
-#%patch4 -p1 -b .errors
-#%patch5 -p1 -b .utf8_support
-#%patch6 -p1 -b .fast_put
-#%patch7 -p1 -b .delete
-#%patch8 -p1 -b .get_with_error
-#%patch9 -p1 -b .get_senderr
-#%patch10 -p1 -b .control_timeout
+%setup -T -c -n %{upstream}-%{realname}-%{version}
+git clone --depth=1 %{url}  ../%{upstream}-%{realname}-%{version} 
+git reset --hard %{commit}
 
 %build
-rebar compile -v
+make
 
 %install
 install -D -m 644 ebin/%{realname}.app $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/%{realname}.app
@@ -64,7 +55,7 @@ install -D -m 644 include/bifrost.hrl $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{rea
 
 %check
 %if %{with check}
-	rebar eunit -v
+	make test
 %endif
 
 %files
@@ -76,11 +67,5 @@ install -D -m 644 include/bifrost.hrl $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{rea
 %{_libdir}/erlang/lib/%{realname}-%{version}/include/bifrost.hrl
 
 %changelog
-* Wed Jun 4 2014 Anatoly L.Berenblit <anaber@spbtv.com> 0.0.0-13
-- DELE returns OK/250 instead OK/200
-
-* Wed May 14 2014 Anatoly L.Berenblit <anaber@spbtv.com> 0.0.0-11
-- custom recv buffer size for increase put's speed
-
-* Fri Jan 10 2014 Anatoly L.Berenblit <anaber@spbtv.com> 0.0.0
+* Thu Nov 13 2014 madrat- 0.0.0
 - Initial release

--- a/erlang-bifrost.spec
+++ b/erlang-bifrost.spec
@@ -1,0 +1,86 @@
+%global realname bifrost
+%global upstream madrat-
+%global debug_package %{nil}
+
+%global commit		5afbc6241b5b9444a4c94aefb92f892ea36b660e
+%global commit_time 20141113
+%global git_tag %(c=%{commit}; echo ${c:0:8})
+%global patchnumber 0
+
+%bcond_without check
+
+Name:		erlang-%{realname}
+Version:	0.0.0
+Release:	%{commit_time}.%{patchnumber}.%{git_tag}%{?dist}
+Summary:	Pluggable Erlang FTP Server
+Group:		Development/Libraries
+License:	MIT
+URL:		http://github.com/madrat-/bifrost
+Source0:	%{upstream}-%{realname}-%{version}-%{git_tag}.tar.bz2
+
+BuildRequires:	erlang-rebar
+BuildRequires:	erlang-meck >= 0.8.1
+
+Requires:	erlang-compiler%{?_isa}
+Requires:	erlang-crypto%{?_isa}
+Requires:	erlang-erts%{?_isa} >= R16
+Requires:	erlang-inets%{?_isa}
+Requires:	erlang-kernel%{?_isa}
+Requires:	erlang-ssl%{?_isa}
+Requires:	erlang-stdlib%{?_isa} >= R16
+Requires:	erlang-syntax_tools%{?_isa}
+Requires:	erlang-meck >= 0.8.1
+Provides:	%{realname} = %{version}-%{release}
+
+
+%description
+Bifrost is an implementation of the FTP protocol that enables you to create an FTP server without worrying about the protocol details. Many legacy business systems still use FTP heavily for data transmission, and Bifrost can help bridge the gap between them and modern distributed systems. For example, using Bifrost you can pretty easily write an FTP server that serves files from Amazon's S3 and a Postgres SQL server instead of a filesystem.
+
+Bifrost also includes FTP/SSL support, if you supply a certificate.
+
+This version is fork of https://github.com/thorstadt/bifrost
+
+%prep
+%setup -q -n %{upstream}-%{realname}-%{version}
+%patch0 -p1 -b .no_deps
+#%patch1 -p2 -b .fix_eunit
+#%patch2 -p1 -b .disconnect
+#%patch3 -p1 -b .up_notifs
+#%patch4 -p1 -b .errors
+#%patch5 -p1 -b .utf8_support
+#%patch6 -p1 -b .fast_put
+#%patch7 -p1 -b .delete
+#%patch8 -p1 -b .get_with_error
+#%patch9 -p1 -b .get_senderr
+#%patch10 -p1 -b .control_timeout
+
+%build
+rebar compile -v
+
+%install
+install -D -m 644 ebin/%{realname}.app $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/%{realname}.app
+install -m 644 ebin/*.beam $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/
+install -D -m 644 include/bifrost.hrl $RPM_BUILD_ROOT%{_libdir}/erlang/lib/%{realname}-%{version}/include/bifrost.hrl
+
+%check
+%if %{with check}
+	rebar eunit -v
+%endif
+
+%files
+%doc LICENSE README.md sample
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/ebin
+%dir %{_libdir}/erlang/lib/%{realname}-%{version}/include
+%{_libdir}/erlang/lib/%{realname}-%{version}/ebin/*
+%{_libdir}/erlang/lib/%{realname}-%{version}/include/bifrost.hrl
+
+%changelog
+* Wed Jun 4 2014 Anatoly L.Berenblit <anaber@spbtv.com> 0.0.0-13
+- DELE returns OK/250 instead OK/200
+
+* Wed May 14 2014 Anatoly L.Berenblit <anaber@spbtv.com> 0.0.0-11
+- custom recv buffer size for increase put's speed
+
+* Fri Jan 10 2014 Anatoly L.Berenblit <anaber@spbtv.com> 0.0.0
+- Initial release

--- a/include/bifrost.hrl
+++ b/include/bifrost.hrl
@@ -9,7 +9,10 @@
           rnfr = undefined,
           module,
           module_state,
-          ssl_allowed = false,
+		  ssl_mode = disabled,	% 'disabled' - NO SSL
+								% 'enabled'  - allowed SSL and FTP
+								% 'only'     - non secured FTP is not allowed
+								% old true and false also supported
           ssl_cert = undefined,
           ssl_key = undefined,
           ssl_ca_cert = undefined,

--- a/include/bifrost.hrl
+++ b/include/bifrost.hrl
@@ -17,7 +17,7 @@
           pb_size = 0,
           control_socket = undefined,
           ssl_socket = undefined,
-          utf8 = false
+          utf8 = true
          }).
 
 -record(file_info,

--- a/include/bifrost.hrl
+++ b/include/bifrost.hrl
@@ -24,7 +24,12 @@
 		  recv_block_size = 64*1024,
 		  send_block_size = 64*1024,
 		  prev_cmd_notify = undefined, % previous command notification data { command, Arguments } | undefined
-		  control_timeout = infinity % control connection timeout for prev-command notification = tcp_gen:timeout()
+		  control_timeout = infinity, % control connection timeout for prev-command notification = tcp_gen:timeout()
+		  port_range = 0	% passive mode's port's range:
+		  					% 0						= ANY,
+							% N 					= {N, 65535}
+							% {minPort, maxPort}
+							% another values - will be skipped
          }).
 
 -record(file_info,

--- a/include/bifrost.hrl
+++ b/include/bifrost.hrl
@@ -17,7 +17,8 @@
           pb_size = 0,
           control_socket = undefined,
           ssl_socket = undefined,
-          utf8 = true
+          utf8 = true,
+		  recv_block_size = 64*1024
          }).
 
 -record(file_info,

--- a/include/bifrost.hrl
+++ b/include/bifrost.hrl
@@ -19,7 +19,9 @@
           ssl_socket = undefined,
           utf8 = true,
 		  recv_block_size = 64*1024,
-		  send_block_size = 64*1024
+		  send_block_size = 64*1024,
+		  prev_cmd_notify = undefined, % previous command notification data { command, Arguments } | undefined
+		  control_timeout = infinity % control connection timeout for prev-command notification = tcp_gen:timeout()
          }).
 
 -record(file_info,

--- a/include/bifrost.hrl
+++ b/include/bifrost.hrl
@@ -18,7 +18,8 @@
           control_socket = undefined,
           ssl_socket = undefined,
           utf8 = true,
-		  recv_block_size = 64*1024
+		  recv_block_size = 64*1024,
+		  send_block_size = 64*1024
          }).
 
 -record(file_info,

--- a/rebar.config
+++ b/rebar.config
@@ -4,3 +4,5 @@
 {deps, [
 	{meck, ".*", {git, "git://github.com/eproxus/meck.git", "0.8.1"}}
 ]}.
+
+{clean_files, ["*.eunit", "ebin/*.beam"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,5 +2,5 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
- {meck, ".*", {git, "git://github.com/eproxus/meck.git", "0.8.1"}}
+	{meck, ".*", {git, "git://github.com/eproxus/meck.git", "0.8.1"}}
 ]}.

--- a/sample/src/bifrost_memory_server.erl
+++ b/sample/src/bifrost_memory_server.erl
@@ -14,6 +14,7 @@
 % Bifrost callbacks
 -export([login/3,
          init/2,
+		 check_user/2,
          current_directory/1,
          make_directory/2,
          change_directory/2,
@@ -47,6 +48,10 @@
 % Initialize the state
 init(InitialState, _) ->
     InitialState.
+
+% All users w/o any requirements
+check_user(State, Arg) ->
+	{ok, State};
 
 % Authenticate the user. Return {false, State} to fail.
 login(State, _Username, _Password) ->

--- a/sample/src/bifrost_memory_server.erl
+++ b/sample/src/bifrost_memory_server.erl
@@ -50,8 +50,13 @@ init(InitialState, _) ->
     InitialState.
 
 % All users w/o any requirements
-check_user(State, Arg) ->
-	{ok, State};
+check_user(State, Username) ->
+	case Username of
+		"root" ->
+			{error, "root account is locked for ftp", State};
+		_Another ->
+			{ok, State}
+	end.
 
 % Authenticate the user. Return {false, State} to fail.
 login(State, _Username, _Password) ->

--- a/sample/src/bifrost_memory_server.erl
+++ b/sample/src/bifrost_memory_server.erl
@@ -92,7 +92,7 @@ change_directory(State, Directory) ->
             {error, State}
     end.
 
-disconnect(_, Reason) ->
+disconnect(_, _Reason) ->
     ok.
 
 % Delete a file
@@ -169,7 +169,7 @@ list_files(State, Directory) ->
 
 % Upload notification is arriving during it with FileRetrievalFun == notification
 % and _Status done or terminated
-put_file(State, ProvidedFileName, _Status, notification) ->
+put_file(State, _ProvidedFileName, notification, _Status) ->
 	{ok, State};
 
 put_file(State, ProvidedFileName, _Mode, FileRetrievalFun) ->

--- a/sample/src/bifrost_memory_server.erl
+++ b/sample/src/bifrost_memory_server.erl
@@ -26,7 +26,7 @@
          rename_file/3,
          site_command/3,
          site_help/1,
-         disconnect/1]).
+         disconnect/2]).
 
 -ifdef(debug).
 -compile(export_all).
@@ -92,7 +92,7 @@ change_directory(State, Directory) ->
             {error, State}
     end.
 
-disconnect(_) ->
+disconnect(_, Reason) ->
     ok.
 
 % Delete a file

--- a/sample/src/bifrost_memory_server.erl
+++ b/sample/src/bifrost_memory_server.erl
@@ -166,6 +166,12 @@ list_files(State, Directory) ->
 % mode could be append or write, but we're only supporting
 % write.
 % FileRetrievalFun is fun() and returns {ok, Bytes, Count} or done
+
+% Upload notification is arriving during it with FileRetrievalFun == notification
+% and _Status done or terminated
+put_file(State, ProvidedFileName, _Status, notification) ->
+	{ok, State};
+
 put_file(State, ProvidedFileName, _Mode, FileRetrievalFun) ->
     FileName = lists:last(string:tokens(ProvidedFileName, "/")),
     Target = absolute_path(State, FileName),

--- a/src/bifrost.erl
+++ b/src/bifrost.erl
@@ -447,7 +447,7 @@ ftp_command(_, Socket, State, syst, _) ->
 ftp_command(Mod, Socket, State, dele, Arg) ->
     case ftp_result(State, Mod:remove_file(State, Arg)) of
         {ok, NewState} ->
-            respond(Socket, 200),
+            respond(Socket, 250), % see RFC 959
             {ok, NewState};
         {error, Reason, NewState} ->
             respond(Socket, 450, format_error("Unable to delete file", Reason)),
@@ -1307,7 +1307,7 @@ remove_file_test() ->
                                          {ok, St}
                                  end),
 
-                     login_test_user(ControlPid, [{"DELE cheese.txt", "200 Command okay.\r\n"},
+                     login_test_user(ControlPid, [{"DELE cheese.txt", "250 Requested file action okay, completed.\r\n"},
                                               {"DELE cheese.txt", "450 Unable to delete file.\r\n"}]),
                      step(ControlPid),
 

--- a/src/bifrost.erl
+++ b/src/bifrost.erl
@@ -140,7 +140,7 @@ get_socket_port(Socket) ->
 %-------------------------------------------------------------------------------
 listen_socket({Start, End}, _TcpOpts, _NextPort) when End < Start ->
 	error_logger:warning_report({bifrost, listen_socket, "no free socket in range"}),
-	{error, eaddrinuse};
+	{error, emfile};
 
 listen_socket({Start, End}, TcpOpts, random) ->
 	% if the for [Start, End] Start<End => Start-1 < End and we have additional item for test

--- a/src/bifrost.erl
+++ b/src/bifrost.erl
@@ -14,28 +14,20 @@
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
-default(Expr, Default) ->
-    case Expr of
-        undefined ->
-            Default;
-        _ ->
-            Expr
-    end.
-
 start_link(HookModule, Opts) ->
     gen_server:start_link(?MODULE, [HookModule, Opts], []).
 
 % gen_server callbacks implementation
 init([HookModule, Opts]) ->
-    Port = default(proplists:get_value(port, Opts), 21),
-    Ssl = default(proplists:get_value(ssl, Opts), false),
+    Port = proplists:get_value(port, Opts, 21),
+    Ssl = proplists:get_value(ssl, Opts, false),
     SslKey = proplists:get_value(ssl_key, Opts),
     SslCert = proplists:get_value(ssl_cert, Opts),
     CaSslCert = proplists:get_value(ca_ssl_cert, Opts),
-    UTF8 = proplists:get_value(utf8, Opts),
+    UTF8 = proplists:get_value(utf8, Opts, false),
     case listen_socket(Port, [{active, false}, {reuseaddr, true}, list]) of
         {ok, Listen} ->
-            IpAddress = default(proplists:get_value(ip_address, Opts), get_socket_addr(Listen)),
+            IpAddress = proplists:get_value(ip_address, Opts, get_socket_addr(Listen)),
             InitialState = #connection_state{module=HookModule,
                                              ip_address=IpAddress,
                                              ssl_allowed=Ssl,

--- a/src/gen_bifrost_server.erl
+++ b/src/gen_bifrost_server.erl
@@ -26,6 +26,6 @@ behaviour_info(callbacks) ->
      {rename_file, 3}, % State, From Path, To Path -> State Change
      {site_command, 3}, % State, Command Name String, Command Args String -> State Change
      {site_help, 1}, % State -> {ok, [HelpInfo]} OR {error, State}
-     {disconnect, 1}]; % State -> State Change
+     {disconnect, 2}]; % State, exit (QUIT command from client) or { error, Reason }  -> State Change
 behaviour_info(_) ->
     undefined.

--- a/src/gen_bifrost_server.erl
+++ b/src/gen_bifrost_server.erl
@@ -24,7 +24,13 @@ behaviour_info(callbacks) ->
 	% GetFun(ByteCount) -> {ok, Bytes, NextGetFun} | {done, NewState} | StateChangeError
 	%
     [{init, 2}, % State, PropList (options) -> State
-     {login, 3}, % State, Username, Password -> {true OR false, State} | 'quit'(disconnect client)
+     {login, 3}, 	% State, Username, Password -> {true OR false, State} | 'quit'(disconnect client)
+     {check_user, 2}, 	% State, Username, {ok, NewState} | {error, Reason, NewState}, 'quit'(disconnect client)
+	 					% SECURE NOTE: Does not use check_user for testing is user available,
+						% and return {ok, State} for all unexisting users,
+						% because USER+PASS obfuscate is user exist and bad password, or no user
+						% This function should used for connection's settings like
+						% USER requires SSL, USER can access from some IP and etc
      {current_directory, 1}, % State -> Path
      {make_directory, 2}, % State, Path -> StateChange
      {change_directory, 2}, % State, Path -> StateChange

--- a/src/gen_bifrost_server.erl
+++ b/src/gen_bifrost_server.erl
@@ -9,7 +9,7 @@
 
 behaviour_info(callbacks) ->
     % Path :: String
-    % State Change :: {ok, State} OR {error, State}
+    % State Change :: {ok, NewState} OR {error, NewState} OR {error, Reason} OR {error, Reason, NewState}
     % File Name :: String
     % HelpInfo :: {Name, Description}
     [{init, 2}, % State, PropList (options) -> State
@@ -26,6 +26,6 @@ behaviour_info(callbacks) ->
      {rename_file, 3}, % State, From Path, To Path -> State Change
      {site_command, 3}, % State, Command Name String, Command Args String -> State Change
      {site_help, 1}, % State -> {ok, [HelpInfo]} OR {error, State}
-     {disconnect, 2}]; % State, exit (QUIT command from client) or { error, Reason }  -> State Change
+     {disconnect, 2}]; % State, exit (QUIT command from client) or { error, Reason }  -> *unused* State Change
 behaviour_info(_) ->
     undefined.


### PR DESCRIPTION
1. EUnit bifrost framework: All tests are uses step()/execute()  w/o direct send message to another process
2. Disconnect function is called in different ways of crash control_connection, not only if everything is fine
3. Client's server module functions should returns {ok, NewState} or {error, Reason, NewState} - for error notification, but for compatibility - old ways error, {error}, {error, Reason} and {error, NewState} are available too
4. UTF-8 is not only FEAT+UTF8 ON, but all clients api functions should get a valid erlang-strings(ucs16 list)
5. Fixed a issue DELETE command, which returns code different from RFC-959
6. put_file may is separated to 'write' and 'notification' for detection of file is translated or file is corrupted and connection is breaked
7. get/put file allows to change socket buffer size (or sending block) - which is impotant to big files (increases transfer speed) and more fast client GUI reaction for small ones (best way is change this values at get_file/put_file)
8. Added rpm spec for redhat like dists
9. Info (at headers and samples) is updated